### PR TITLE
Added support for Pipeline jobs

### DIFF
--- a/src/main/java/io/relution/jenkins/awssqs/interfaces/EventTriggerMatcher.java
+++ b/src/main/java/io/relution/jenkins/awssqs/interfaces/EventTriggerMatcher.java
@@ -16,14 +16,14 @@
 
 package io.relution.jenkins.awssqs.interfaces;
 
-import hudson.model.AbstractProject;
+import hudson.model.Job;
 import io.relution.jenkins.awssqs.model.entities.codecommit.ExecuteJenkinsJobEvent;
 
 import java.util.List;
 
 
 /**
- * Interface definition for classes that match events to {@link AbstractProject}s. If an event
+ * Interface definition for classes that match events to {@link Job}s. If an event
  * matches a project its build process should be triggered.
  */
 public interface EventTriggerMatcher {
@@ -31,9 +31,9 @@ public interface EventTriggerMatcher {
     /**
      * Returns a value indicating whether any of the specified events matches the specified job.
      * @param events The collection of {@link Event}s to test against the job.
-     * @param job The {@link AbstractProject} to test against.
+     * @param job The {@link Job} to test against.
      * @return {@code true} if any of the specified events matches the specified job; otherwise,
      * {@code false}.
      */
-    boolean matches(List<ExecuteJenkinsJobEvent> events, AbstractProject<?, ?> job);
+    boolean matches(List<ExecuteJenkinsJobEvent> events, Job<?, ?> job);
 }

--- a/src/main/java/io/relution/jenkins/awssqs/model/EventTriggerMatcherImpl.java
+++ b/src/main/java/io/relution/jenkins/awssqs/model/EventTriggerMatcherImpl.java
@@ -16,7 +16,7 @@
 
 package io.relution.jenkins.awssqs.model;
 
-import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
 import hudson.scm.SCM;
@@ -34,7 +34,7 @@ import java.util.List;
 public class EventTriggerMatcherImpl implements EventTriggerMatcher {
 
     @Override
-    public boolean matches(final List<ExecuteJenkinsJobEvent> events, final AbstractProject<?, ?> job) {
+    public boolean matches(final List<ExecuteJenkinsJobEvent> events, final Job<?, ?> job) {
         if (events == null || job == null) {
             return false;
         }

--- a/src/main/java/io/relution/jenkins/awssqs/util/JobInfoHelpers.java
+++ b/src/main/java/io/relution/jenkins/awssqs/util/JobInfoHelpers.java
@@ -1,0 +1,33 @@
+package io.relution.jenkins.awssqs.util;
+
+import hudson.model.AbstractProject;
+import hudson.model.Job;
+import jenkins.model.ParameterizedJobMixIn;
+
+/**
+ * Job utility class.
+ */
+public class JobInfoHelpers {
+
+    private JobInfoHelpers() {
+        throw new IllegalAccessError("Do not instantiate it");
+    }
+
+    /**
+     * This method converts any child class of {@link Job} (ie, {@link AbstractProject}
+     * to {@link ParameterizedJobMixIn} to use it in workflow
+     *
+     * @param job to wrap
+     * @param <T> any child type of Job
+     *
+     * @return ParameterizedJobMixIn
+     */
+    public static <T extends Job> ParameterizedJobMixIn asParameterizedJobMixIn(final T job) {
+        return new ParameterizedJobMixIn() {
+            @Override
+            protected Job asJob() {
+                return job;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Changes will allow a user to create a **Pipeline job** and enable "_Trigger build when a message is published to an Amazon SQS queue_".