### PR TITLE
Adding a filter string to SQSTrigger to enable conditional builds

### DIFF
--- a/src/main/java/io/relution/jenkins/awssqs/interfaces/SQSQueueListener.java
+++ b/src/main/java/io/relution/jenkins/awssqs/interfaces/SQSQueueListener.java
@@ -35,6 +35,13 @@ public interface SQSQueueListener {
     String getQueueUuid();
 
     /**
+     * The filter string of an build trigger that can be used to filter incoming messages and
+     * conditionally trigger builds.
+     * @return The string used to filter incoming message bodies. An empty value or '*' are treated as wildcards.
+     */
+    String getFilterString();
+
+    /**
      * The method to be invoked when new messages arrive in the SQS queue this listener is
      * associated with.
      * @param messages The collection of {@link Message} instances that were posted to the queue.

--- a/src/main/resources/io/relution/jenkins/awssqs/SQSTrigger/config.jelly
+++ b/src/main/resources/io/relution/jenkins/awssqs/SQSTrigger/config.jelly
@@ -26,4 +26,9 @@
 		field="queueUuid">
 		<f:select />
 	</f:entry>
+	<f:entry
+		title="${%SQS message filter}"
+		field="filterString">
+		<f:textbox default="*" />
+	</f:entry>
 </j:jelly>

--- a/src/main/resources/io/relution/jenkins/awssqs/SQSTrigger/help-filterString.html
+++ b/src/main/resources/io/relution/jenkins/awssqs/SQSTrigger/help-filterString.html
@@ -1,0 +1,7 @@
+<div>
+This property allows the operator to specify a filter string to be applied against incoming messages from the specified queue.
+    <ul>
+        <li>An empty value or value of '*' will cause all incoming messages to trigger a build.</li>
+        <li>Any other value will be compared to the incoming message body. A build will only trigger if there is a match.</li>
+    </ul>
+</div>


### PR DESCRIPTION
Proposed: adding a new parameter to the SQS build trigger called 'filterString'. This string is used to match against the incoming SQS message body. If the string matches, or is a wildcard value, the build is triggered. If the filter does not match, it skips the build. This allows a single SQS queue to be used to trigger multiple independent builds/jobs rather than using separate queues.

This change includes a new textbox in the SQSTrigger config to expose the filterString to the user. This addresses [Issue #19](https://github.com/jenkinsci/aws-sqs-plugin/issues/19) I filed earlier today.