### PR TITLE
enhancements to message retrieval and queue polling

### DIFF
--- a/src/main/java/io/relution/jenkins/awssqs/SQSTrigger.java
+++ b/src/main/java/io/relution/jenkins/awssqs/SQSTrigger.java
@@ -17,6 +17,7 @@
 package io.relution.jenkins.awssqs;
 
 import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.MessageAttributeValue;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import hudson.DescriptorExtensionList;
@@ -195,10 +196,8 @@ public class SQSTrigger extends Trigger<Job<?, ?>> implements io.relution.jenkin
         Map<String, String> jobParams = new HashMap<>();
 
         // add job parameters from the message (N.B. won't work post Jenkins v2+) @see https://wiki.jenkins-ci.org/display/JENKINS/Plugins+affected+by+fix+for+SECURITY-170
-        for (Map.Entry<String, String> att : message.getAttributes().entrySet()) {
-            if (StringUtils.isNotBlank(att.getKey())) {
-                jobParams.put("sqs_" + att.getKey(), att.getValue());
-            }
+	    for (Map.Entry<String, MessageAttributeValue> att : message.getMessageAttributes().entrySet()) {
+	        jobParams.put("sqs_" + att.getKey(), att.getValue().getStringValue());
         }
         jobParams.put("sqs_body", message.getBody());
         jobParams.put("sqs_messageId", message.getMessageId());

--- a/src/main/java/io/relution/jenkins/awssqs/SQSTrigger.java
+++ b/src/main/java/io/relution/jenkins/awssqs/SQSTrigger.java
@@ -197,7 +197,9 @@ public class SQSTrigger extends Trigger<Job<?, ?>> implements io.relution.jenkin
 
         // add job parameters from the message (N.B. won't work post Jenkins v2+) @see https://wiki.jenkins-ci.org/display/JENKINS/Plugins+affected+by+fix+for+SECURITY-170
 	    for (Map.Entry<String, MessageAttributeValue> att : message.getMessageAttributes().entrySet()) {
-	        jobParams.put("sqs_" + att.getKey(), att.getValue().getStringValue());
+            if (StringUtils.isNotBlank(att.getKey()) && att.getValue() != null) {
+                jobParams.put("sqs_" + att.getKey(), att.getValue().getStringValue());
+            }
         }
         jobParams.put("sqs_body", message.getBody());
         jobParams.put("sqs_messageId", message.getMessageId());

--- a/src/main/java/io/relution/jenkins/awssqs/interfaces/SQSQueue.java
+++ b/src/main/java/io/relution/jenkins/awssqs/interfaces/SQSQueue.java
@@ -56,6 +56,18 @@ public interface SQSQueue extends AWSCredentials {
     int getWaitTimeSeconds();
 
     /**
+     * Returns the maximum number of buildable jobs allowed in the build queue.
+     * @return The maximum number of buildable jobs allowed in the build queue.
+     */
+    int getMaxNumberOfJobQueue();
+
+    /**
+     * Returns a value indicating whether SQS messages should be kept after retrieval.
+     * @return {@code true} if messages should be kept after retrieval; otherwise, {@code false}.
+     */
+    boolean isKeepQueueMessages();
+
+    /**
      * Returns the maximum number of messages that a request should request.
      * @return The maximum number of messages a receive message request should request from the
      * queue.

--- a/src/main/java/io/relution/jenkins/awssqs/net/SQSChannelImpl.java
+++ b/src/main/java/io/relution/jenkins/awssqs/net/SQSChannelImpl.java
@@ -62,7 +62,7 @@ public class SQSChannelImpl implements SQSChannel {
             this.logRequestCount();
 
             final ReceiveMessageRequest request = this.factory.createReceiveMessageRequest(this.queue);
-            final ReceiveMessageResult result = this.sqs.receiveMessage(request);
+            final ReceiveMessageResult result = this.sqs.receiveMessage(request.withMessageAttributeNames("All"));
 
             if (result == null) {
                 return Collections.emptyList();

--- a/src/main/java/io/relution/jenkins/awssqs/threading/SQSQueueMonitorImpl.java
+++ b/src/main/java/io/relution/jenkins/awssqs/threading/SQSQueueMonitorImpl.java
@@ -201,6 +201,12 @@ public class SQSQueueMonitorImpl implements SQSQueueMonitor {
 
         if (this.notifyListeners(messages) && this.queue.isKeepQueueMessages() == false) {
             this.channel.deleteMessages(messages);
+        } else if (!messages.isEmpty() && this.queue.isKeepQueueMessages() == true) {
+            try {
+                Thread.sleep(2000);
+            } catch (InterruptedException ex) {
+               Log.warning("Exception %s occurred while sleeping after message retrieval on %s", ex.toString(), this.channel);
+            }
         }
     }
 

--- a/src/main/java/io/relution/jenkins/awssqs/threading/SQSQueueMonitorImpl.java
+++ b/src/main/java/io/relution/jenkins/awssqs/threading/SQSQueueMonitorImpl.java
@@ -199,9 +199,9 @@ public class SQSQueueMonitorImpl implements SQSQueueMonitor {
             return;
         }
 
-        if (this.notifyListeners(messages) && this.queue.isKeepQueueMessages() == false) {
+        if (this.notifyListeners(messages) && !this.queue.isKeepQueueMessages()) {
             this.channel.deleteMessages(messages);
-        } else if (!messages.isEmpty() && this.queue.isKeepQueueMessages() == true) {
+        } else if (!messages.isEmpty() && this.queue.isKeepQueueMessages()) {
             try {
                 Thread.sleep(2000);
             } catch (InterruptedException ex) {

--- a/src/main/java/io/relution/jenkins/awssqs/threading/SQSQueueMonitorSchedulerImpl.java
+++ b/src/main/java/io/relution/jenkins/awssqs/threading/SQSQueueMonitorSchedulerImpl.java
@@ -161,6 +161,14 @@ public class SQSQueueMonitorSchedulerImpl implements SQSQueueMonitorScheduler {
                 return true;
             }
 
+            if (current.getMaxNumberOfJobQueue() != queue.getMaxNumberOfJobQueue()) {
+                return true;
+            }
+
+            if (current.isKeepQueueMessages() != queue.isKeepQueueMessages()) {
+                return true;
+            }
+
             if (current.getWaitTimeSeconds() != queue.getWaitTimeSeconds()) {
                 return true;
             }

--- a/src/main/resources/io/relution/jenkins/awssqs/SQSTriggerQueue/config.jelly
+++ b/src/main/resources/io/relution/jenkins/awssqs/SQSTriggerQueue/config.jelly
@@ -53,6 +53,16 @@
 				field="maxNumberOfMessages">
 				<f:textbox default="10" />
 			</f:entry>
+			<f:entry
+				title="${%Max. number of jobs in build queue}"
+				field="maxNumberOfJobQueue">
+				<f:textbox default="1000" />
+			</f:entry>
+			<f:entry
+				title="${%Keep SQS messages}"
+				field="keepQueueMessages">
+				<f:checkbox />
+			</f:entry>
 		</f:advanced>
 	</f:section>
 </j:jelly>

--- a/src/main/resources/io/relution/jenkins/awssqs/SQSTriggerQueue/help-keepQueueMessages.html
+++ b/src/main/resources/io/relution/jenkins/awssqs/SQSTriggerQueue/help-keepQueueMessages.html
@@ -1,0 +1,8 @@
+<div>
+By default messages will be deleted from SQS after they are retrieved. Enable this setting if you would like messages to not
+be removed from SQS after retrieval. Your job configuration will probably want to remove these messages or they will be 
+retrieved again after the visibility timeout passes. 
+<p/>
+The goal is to prevent messages from going unprocessed when something crashes before the Jenkins job completes.
+<p/>
+</div>

--- a/src/main/resources/io/relution/jenkins/awssqs/SQSTriggerQueue/help-maxNumberOfJobQueue.html
+++ b/src/main/resources/io/relution/jenkins/awssqs/SQSTriggerQueue/help-maxNumberOfJobQueue.html
@@ -1,0 +1,8 @@
+<div>
+The maximum number of buildable items in the build job queue before pausing the retrieval of SQS messages.
+Values can be from 0 (don't pull messages from SQS when there is a build job queue) to 100,000. Default is 1000. Pause set to  
+15 seconds.
+<p/>
+The goal is to prevent overloading a busy Jenkins master that has a build queue with additional work.
+<p/>
+</div>

--- a/src/main/resources/io/relution/jenkins/awssqs/i18n/sqstriggerqueue/Messages.properties
+++ b/src/main/resources/io/relution/jenkins/awssqs/i18n/sqstriggerqueue/Messages.properties
@@ -6,3 +6,4 @@ warningUrl=Name or URL of an SQS queue is required
 errorUrlCodecommit=This is a CodeCommit URL, please provide a queue name or SQS URL
 errorUrlUnknown=This is not an SQS URL, please provide a queue name or SQS URL
 errorUuid=UUID is not unique
+errorMaxNumberOfJobQueue=Max. number of buildable items in the job queue must be a number between 0 and 100000

--- a/src/main/resources/io/relution/jenkins/awssqs/i18n/sqstriggerqueue/Messages.properties
+++ b/src/main/resources/io/relution/jenkins/awssqs/i18n/sqstriggerqueue/Messages.properties
@@ -1,9 +1,9 @@
 displayName=An Amazon SQS queue configuration
 errorWaitTimeSeconds=Wait Time must be a number between 1 and 20
 errorMaxNumberOfMessages=Max. number of messages must be a number between 1 and 10
+errorMaxNumberOfJobQueue=Max. number of buildable items in the job queue must be a number between 0 and 100000
 infoUrlSqs=You can use \"%s\" instead of the full URL
 warningUrl=Name or URL of an SQS queue is required
 errorUrlCodecommit=This is a CodeCommit URL, please provide a queue name or SQS URL
 errorUrlUnknown=This is not an SQS URL, please provide a queue name or SQS URL
 errorUuid=UUID is not unique
-errorMaxNumberOfJobQueue=Max. number of buildable items in the job queue must be a number between 0 and 100000

--- a/src/main/resources/io/relution/jenkins/awssqs/i18n/sqstriggerqueue/Messages_de.properties
+++ b/src/main/resources/io/relution/jenkins/awssqs/i18n/sqstriggerqueue/Messages_de.properties
@@ -6,3 +6,4 @@ warningUrl=Name oder URL einer SQS Queue ist erforderlich
 errorUrlCodecommit=Dies ist eine CodeCommit URL, bitte Name einer Queue oder SQS URL angeben
 errorUrlUnknown=Dies ist keine SQS URL, bitte Name einer Queue oder SQS URL angeben
 errorUuid=UUID ist nicht einzigartig
+errorMaxNumberOfJobQueue=Max. Anzahl der Build-Aufgaben in der Build-Warteschlange muss eine Zahl zwischen 0 und 100000 sein

--- a/src/test/java/io/relution/jenkins/awssqs/SQSTriggerQueueTest.java
+++ b/src/test/java/io/relution/jenkins/awssqs/SQSTriggerQueueTest.java
@@ -58,7 +58,7 @@ public class SQSTriggerQueueTest {
     @Test
     public void shouldSetDefaults() {
         // Cannot mock or create an instance of final hudson.util.Secret, so null it is
-        final SQSTriggerQueue queue = new SQSTriggerQueue(null, "name", null, 0, 0);
+        final SQSTriggerQueue queue = new SQSTriggerQueue(null, "name", null, 0, 0, null, false);
         queue.setFactory(this.sqsFactory);
 
         assertThat(queue.getUuid()).isNotEmpty();
@@ -72,11 +72,13 @@ public class SQSTriggerQueueTest {
 
         assertThat(queue.getWaitTimeSeconds()).isEqualTo(20);
         assertThat(queue.getMaxNumberOfMessages()).isEqualTo(10);
+        assertThat(queue.getMaxNumberOfJobQueue()).isEqualTo(1000);
+        assertThat(queue.isKeepQueueMessages()).isFalse();
     }
 
     @Test
     public void shouldHaveNoExplicitEndpoint() {
-        final SQSTriggerQueue queue = new SQSTriggerQueue(null, "test-queue", null, 0, 0);
+        final SQSTriggerQueue queue = new SQSTriggerQueue(null, "test-queue", null, 0, 0, 0, false);
         queue.setFactory(this.sqsFactory);
 
         assertThat(queue.getUrl()).isEqualTo("mock://sqs.url");
@@ -92,7 +94,9 @@ public class SQSTriggerQueueTest {
                 "https://sqs.us-east-1.amazonaws.com/929548749884/test-queue",
                 null,
                 0,
-                0);
+                0,
+                0,
+                false);
         queue.setFactory(this.sqsFactory);
 
         assertThat(queue.getUrl()).isEqualTo("https://sqs.us-east-1.amazonaws.com/929548749884/test-queue");
@@ -108,7 +112,9 @@ public class SQSTriggerQueueTest {
                 "https://git-codecommit.us-east-1.amazonaws.com/v1/repos/test",
                 null,
                 0,
-                0);
+                0,
+                0,
+                false);
         queue.setFactory(this.sqsFactory);
 
         assertThat(queue.getUrl()).isEqualTo("mock://sqs.url");

--- a/src/test/java/io/relution/jenkins/awssqs/net/SQSQueueImplTest.java
+++ b/src/test/java/io/relution/jenkins/awssqs/net/SQSQueueImplTest.java
@@ -68,7 +68,7 @@ public class SQSQueueImplTest {
         final ReceiveMessageResult result = Mockito.mock(ReceiveMessageResult.class);
 
         Mockito.when(this.factory.createReceiveMessageRequest(this.queue)).thenReturn(request);
-        Mockito.when(this.sqs.receiveMessage(request)).thenReturn(result);
+        Mockito.when(this.sqs.receiveMessage(request.withMessageAttributeNames("All"))).thenReturn(result);
         Mockito.when(result.getMessages()).thenReturn(this.messages);
 
         final List<Message> messages = this.channel.getMessages();


### PR DESCRIPTION
We have made the following enhancements to the SQS plugin for supporting high volume SQS queues in a multi Jenkins master environment.

- Retrieve message attributes so they can be passed in as job parameters
- Skip polling SQS queue when Jenkins build job queue reaches configured threshold
- Skip polling SQS queue when Jenkins is quieting down for shutdown
- Option to keep SQS queue messages after retrieval so Jenkins jobs can remove them after successful processing
- Sleep 2 seconds after pulling messages from SQS queues to prevent overloading the Jenkins master