### PR TITLE
Add joda-time as an explicit dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <multiple-scms.version>0.6</multiple-scms.version>
         <commons-lang3.version>3.7</commons-lang3.version>
         <plain-credentials.version>1.4</plain-credentials.version>
+        <joda-time.version>2.10.5</joda-time.version>
         <htmlunit.version>2.20</htmlunit.version>
         <mockito-core.version>2.12.0</mockito-core.version>
         <assertj-core.version>3.8.0</assertj-core.version>
@@ -140,6 +141,12 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
             <version>${plain-credentials.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>${joda-time.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Jenkins version 2.204
aws-sqs plugin version 2.0.1

When I attempt to add a queue as a trigger source and click "Test Access", I get a stack trace amounting to:

```
Caused: java.lang.NoClassDefFoundError: org/joda/time/ReadableInstant
	at com.amazonaws.auth.EC2CredentialsFetcher.fetchCredentials(EC2CredentialsFetcher.java:154)
```

because joda-time isn't installed. This PR adds joda-time to pom.xml. I've rebuilt the plugin locally [1] and tested that this solves the problem.

I think this also fixes #27, though the stack trace I get is slightly different because I wasn't using any explicit credentials (i.e. using the Jenkins EC2 instance profile).

[1] `docker run -it --rm -v $(pwd):$(pwd) -w $(pwd) -u 1000:1000 -v /tmp/.m2:/.m2 maven:3.6.2-ibmjava-8-alpine mvn install`