### PR TITLE
Add support for configuration-as-code

### DIFF
--- a/src/main/java/io/relution/jenkins/awssqs/SQSTrigger.java
+++ b/src/main/java/io/relution/jenkins/awssqs/SQSTrigger.java
@@ -49,6 +49,7 @@ import net.sf.json.JSONObject;
 import org.apache.commons.jelly.XMLOutput;
 import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -83,7 +84,7 @@ public class SQSTrigger extends Trigger<Job<?, ?>> implements io.relution.jenkin
         this.queueUuid = queueUuid;
         this.disableCodeCommit = false;
     }
-    
+
     @DataBoundConstructor
     public SQSTrigger(final String queueUuid, final boolean disableCodeCommit) {
         this.queueUuid = queueUuid;
@@ -375,8 +376,7 @@ public class SQSTrigger extends Trigger<Job<?, ?>> implements io.relution.jenkin
         public boolean configure(final StaplerRequest req, final JSONObject json) throws FormException {
             final Object sqsQueues = json.get(KEY_SQS_QUEUES);
 
-            this.sqsQueues = req.bindJSONToList(io.relution.jenkins.awssqs.SQSTriggerQueue.class, sqsQueues);
-            this.initQueueMap();
+            this.setSqsQueues(req.bindJSONToList(io.relution.jenkins.awssqs.SQSTriggerQueue.class, sqsQueues));
             this.save();
 
             EventBroker.getInstance().post(new ConfigurationChangedEvent());
@@ -391,6 +391,12 @@ public class SQSTrigger extends Trigger<Job<?, ?>> implements io.relution.jenkin
                 return Collections.emptyList();
             }
             return this.sqsQueues;
+        }
+
+        @DataBoundSetter
+        public void setSqsQueues(List<io.relution.jenkins.awssqs.SQSTriggerQueue> sqsQueues) {
+            this.sqsQueues = sqsQueues;
+            this.initQueueMap();
         }
 
         public SQSQueue getSqsQueue(final String uuid) {

--- a/src/main/java/io/relution/jenkins/awssqs/SQSTriggerQueue.java
+++ b/src/main/java/io/relution/jenkins/awssqs/SQSTriggerQueue.java
@@ -62,7 +62,7 @@ public class SQSTriggerQueue extends AbstractDescribableImpl<SQSTriggerQueue> im
     private static final int MAX_NUMBER_OF_MESSAGES_DEFAULT = 10;
     private static final int MAX_NUMBER_OF_MESSAGES_MIN = 1;
     private static final int MAX_NUMBER_OF_MESSAGES_MAX = 10;
-    
+
     private static final int MAX_NUMBER_OF_JOB_QUEUE_MIN = 0;
     private static final int MAX_NUMBER_OF_JOB_QUEUE_MAX = 100000;
     private static final int MAX_NUMBER_OF_JOB_QUEUE_DEFAULT = 1000;
@@ -139,7 +139,7 @@ public class SQSTriggerQueue extends AbstractDescribableImpl<SQSTriggerQueue> im
                 MAX_NUMBER_OF_MESSAGES_MIN,
                 MAX_NUMBER_OF_MESSAGES_MAX,
                 MAX_NUMBER_OF_MESSAGES_DEFAULT);
-        
+
         this.maxNumberOfJobQueue = this.limit(
                 maxNumberOfJobQueue,
                 MAX_NUMBER_OF_JOB_QUEUE_MIN,
@@ -530,7 +530,7 @@ public class SQSTriggerQueue extends AbstractDescribableImpl<SQSTriggerQueue> im
 
                 final String url = result.getQueueUrl();
                 if ((credentialsId == null) || credentialsId.isEmpty())    {
-                    return FormValidation.error("No credentials set");
+                    return FormValidation.ok("Access to %s successful\n(%s)", queue.getName(), url);
                 } else {
                     return FormValidation.ok("Access to %s successful\n(%s),\ncredentials store ID=(%s)",
                         queue.getName(), url, queue.getCredentialsId());


### PR DESCRIPTION
This makes it possible to set up queues via the configuration-as-code plugin. That looks like:

```
unclassified:
  sQSTrigger:                
    sqsQueues:           
    - keepQueueMessages: false
      maxNumberOfJobQueue: 1000
      maxNumberOfMessages: 10    
      nameOrUrl: "queuename"
      uuid: "b8ce072e-e251-4c4b-84db-8a0827a0f2a2"
      waitTimeSeconds: 20
```