### PR TITLE
Remove unneeded configuration in buildPlugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,9 +9,5 @@ buildPlugin(
     ],
     jenkinsVersions: [
         '2.63'
-    ],
-    findbugs: [
-        run: false
-    ],
-    failFast: true
+    ]
 )


### PR DESCRIPTION
Spotbugs reporting is being enabled by default in https://github.com/jenkins-infra/pipeline-library/pull/121, update to parent pom 4.x to use spotbugs instead of findbugs.